### PR TITLE
fix default table markup

### DIFF
--- a/app/models/table_widget.rb
+++ b/app/models/table_widget.rb
@@ -4,8 +4,8 @@ class TableWidget < Widget
   default_for :table do |a,b|
     "<table class='table'>
       <thead>
-        <tr><th>Headline</th><th>Headline</th></tr><
-      /thead>
+        <tr><th>Headline</th><th>Headline</th></tr>
+      </thead>
       <tbody>
         <tr><td>Content</td><td>Content</td></tr>
         <tr><td>Content</td><td>Content</td></tr>


### PR DESCRIPTION
Version 0.6.1 introduces a problem when you create a new table widget:

<img width="606" alt="screen shot 2016-05-03 at 12 17 13" src="https://cloud.githubusercontent.com/assets/2295856/14980464/20505996-1129-11e6-98bb-1918bfb42618.png">

This leads to invalid markup and the jquery editor fails, throwing nothing but JS errors, rendering the visitor unable to modify or edit the table.