### PR TITLE
Fix addBottom on HeadLine

### DIFF
--- a/app/assets/javascripts/scrivito_table_widget/jquery.edit.table.js
+++ b/app/assets/javascripts/scrivito_table_widget/jquery.edit.table.js
@@ -97,7 +97,7 @@
   }
 
   $.fn.edittable.clear = function() {
-    if(initialized) {
+    if(initialized && activeTable.length > 0) {
       var text = activeTable.get(0).outerHTML;
       var field = cmsField;
       activeTable = null;
@@ -109,6 +109,9 @@
       rows = 0;
       cols = 0;
       return {text: text, cmsField: field};
+    }
+    else {
+      initialized = false;
     }
   }
 
@@ -282,8 +285,15 @@
 
   $.fn.edittable.addBottom = function() {
     var newRow = "<tr>"+ new Array(cols + 1).join("<td>Content</td>"); +"</tr>";
+    var insertPoint;
 
-    $(newRow).insertAfter( activeElement.parents('tr') );
+    if (activeElement.closest('thead').length) {
+      insertPoint = activeTable.find("tbody tr").first();
+    } else {
+      insertPoint = activeElement.parents('tr');
+    }
+
+    $(newRow).insertAfter(insertPoint);
     rows += 1;
     $.fn.edittable.setButtonPositions();
     $.fn.edittable.save();
@@ -293,7 +303,7 @@
     var pos = activeElement.index();
 
     activeTable.find("thead tr").each(function(index, row) {
-      $($(row).find("th")[pos]).before("<th>Head</th>");
+      $($(row).find("th")[pos]).before("<th>Headline</th>");
     });
 
     activeTable.find("tbody tr").each(function(index, row) {
@@ -309,7 +319,7 @@
     var pos = activeElement.index();
 
     activeTable.find("thead tr").each(function(index, row) {
-      $($(row).find("th")[pos]).after("<th>Head</th>");
+      $($(row).find("th")[pos]).after("<th>Headline</th>");
     });
 
     activeTable.find("tbody tr").each(function(index, row) {

--- a/lib/scrivito_table_widget/version.rb
+++ b/lib/scrivito_table_widget/version.rb
@@ -1,3 +1,3 @@
 module ScrivitoTableWidget
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end


### PR DESCRIPTION
On a table if a row was added when selecting the HeadLine it would add the row in the thead and not the tbody, additionally this behaviour would create blank spots on the table after adding colums.

The changes line [100](https://github.com/Scrivito/scrivito_table_widget/compare/master...exadeci:master#diff-3847fbd00aaf198cfeeb16cea48269a9R100) prevents the table from entering an unusable state (until a page reload).

The changes line [288](https://github.com/Scrivito/scrivito_table_widget/compare/master...exadeci:master#diff-3847fbd00aaf198cfeeb16cea48269a9R288) prevents the blank cells bug to happen.
![image](https://cloud.githubusercontent.com/assets/1394130/15768339/290d023c-2993-11e6-848d-d77712a818bc.png)

Additionally, I changed the text of the inserted cells to match the default ones of the table. (Head to HeadLine)