### PR TITLE
unbind widget click listener as stopPropagation does not work properly

### DIFF
--- a/app/assets/javascripts/scrivito_table_widget/tableEditor.js
+++ b/app/assets/javascripts/scrivito_table_widget/tableEditor.js
@@ -8,8 +8,10 @@
     activate: function(element) {
       $(element).on('click', function(event) {
         $(element).edittable(event);
-        scrivito.editors.medium_editor.activate(element);
-        $(this).unbind('click');
+
+        if (!$(this).data('medium-editor-element')) {
+          scrivito.editors.medium_editor.activate(element);
+        }
       });
 
       $('body').on('click', function(event) {

--- a/app/assets/javascripts/scrivito_table_widget/tableEditor.js
+++ b/app/assets/javascripts/scrivito_table_widget/tableEditor.js
@@ -9,7 +9,7 @@
       $(element).on('click', function(event) {
         $(element).edittable(event);
         scrivito.editors.medium_editor.activate(element);
-        event.stopPropagation();
+        $(this).unbind('click');
       });
 
       $('body').on('click', function(event) {

--- a/app/assets/javascripts/scrivito_table_widget/tableEditor.js
+++ b/app/assets/javascripts/scrivito_table_widget/tableEditor.js
@@ -12,6 +12,7 @@
         if (!$(this).data('medium-editor-element')) {
           scrivito.editors.medium_editor.activate(element);
         }
+        event.stopPropagation();
       });
 
       $('body').on('click', function(event) {


### PR DESCRIPTION
The `event.stopPropagation()` does not have any effect here, which leads to numerous widget initialisations on each click. One side effect is that the list-indentation of the Medium-Editor does not work as expected. However, I am not sure why the event continues to propagate.

So, my solution would be to unbind the event handler.