### PR TITLE
Use editor API only if present

### DIFF
--- a/app/assets/javascripts/scrivito_table_widget/tableEditor.js
+++ b/app/assets/javascripts/scrivito_table_widget/tableEditor.js
@@ -25,7 +25,9 @@
   };
 
   scrivito.on('content', function() {
-    return scrivito.define_editor('table_editor', table_editor);
+    if (scrivito.in_editable_view()) {
+      scrivito.define_editor('table_editor', table_editor);
+    }
   });
 
 })(jQuery, this);


### PR DESCRIPTION
Otherwise it leads to a JS error: `TypeError: scrivito.define_editor is not a function`
Please note: Blindfix. I didn't test this change.